### PR TITLE
chore: Upgrade checkout and setup-node versions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: 16
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -34,7 +34,7 @@ jobs:
         run: |
           npm ci --cache .npm --prefer-offline
       - name: Cache base files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./*
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get base files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./*
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get base files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./*


### PR DESCRIPTION
The latest GitHub Actions cache service outage surfaced that we should be running on v3 of `actions/checkout` and `actions/setup-node`. The issue was hot-fixed in `actions/checkout` v3 before GitHub fixed the outage.

Had we been on v3, our workflows could have ran successfully sooner.