### PR TITLE
feat: Forward Collibra status codes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,14 +22,6 @@
     "@typescript-eslint"
   ],
   "rules": {
-    "semi": ["error", "never"],
-    "quotes": ["error", "double"],
-    "react/function-component-definition": [2, { "namedComponents": "arrow-function" }],
-    "react/jsx-filename-extension": [2, { "extensions": [".jsx", ".tsx"] }],
-    "react/require-default-props": 0,
-    "import/prefer-default-export": 0,
-    "import/no-default-export": 1,
-    "import/order": ["error", { "newlines-between": "always", "alphabetize": { "order": "asc" } }],
     "import/extensions": [
       "error",
       "ignorePackages",
@@ -39,7 +31,16 @@
         "ts": "never",
         "tsx": "never"
       }
-   ]
+    ],
+    "import/no-default-export": 1,
+    "import/order": ["error", { "newlines-between": "always", "alphabetize": { "order": "asc" } }],
+    "import/prefer-default-export": 0,
+    "lines-between-class-members": "off",
+    "quotes": ["error", "double"],
+    "react/function-component-definition": [2, { "namedComponents": "arrow-function" }],
+    "react/jsx-filename-extension": [2, { "extensions": [".jsx", ".tsx"] }],
+    "react/require-default-props": 0,
+    "semi": ["error", "never"]
   },
   "overrides": [
     {

--- a/lib/HttpClient.ts
+++ b/lib/HttpClient.ts
@@ -1,6 +1,8 @@
 import axios, { Axios, AxiosError } from "axios"
 import qs from "query-string"
 
+import { HttpError } from "./HttpError"
+
 type HttpMethod = "GET"
   | "DELETE"
   | "HEAD"
@@ -24,13 +26,6 @@ type HttpRequestConfig = {
   body?: any
   method?: HttpMethod,
   headers?: Record<string, any>
-}
-
-export interface HttpError {
-  body?: any
-  headers: Record<string, any>
-  statusCode: number
-  statusMessage: string
 }
 
 export class HttpClient {
@@ -64,16 +59,15 @@ export class HttpClient {
         body: res.data,
       }
     } catch (error) {
-      if (error instanceof AxiosError) {
-        throw Object.assign(new Error(`${error.config.method?.toUpperCase()} request to ${error.config.url} failed: ${error.response?.status} (${error.response?.statusText})`), {
-          body: error.response?.data,
-          code: error.code,
-          headers: error.response?.headers,
-          statusCode: error.response?.status,
-          statusMessage: error.response?.statusText,
-        })
-      }
-      throw error
+      const err = error as AxiosError
+
+      console.log(`${err.config.method?.toUpperCase()} request to ${err.config.url} failed: ${err.response?.status} (${err.response?.statusText})`)
+      throw new HttpError(
+        err.message,
+        err.response!.status,
+        err.response!.headers,
+        err.response!.data,
+      )
     }
   }
 

--- a/lib/HttpError.ts
+++ b/lib/HttpError.ts
@@ -1,0 +1,17 @@
+import { STATUS_CODES } from "http"
+
+export class HttpError extends Error {
+  body?: any
+  headers: Record<string, any>
+  statusCode: number
+  statusMessage: string
+
+  constructor(message: string, statusCode: number, headers: Record<string, any>, body?: any) {
+    super(message)
+
+    this.body = body
+    this.headers = headers
+    this.statusCode = statusCode
+    this.statusMessage = STATUS_CODES[statusCode]!
+  }
+}

--- a/pages/api/assets/[id]/index.ts
+++ b/pages/api/assets/[id]/index.ts
@@ -2,6 +2,7 @@ import { NextApiHandler } from "next"
 
 import { config } from "../../../../config"
 import { HttpClient } from "../../../../lib/HttpClient"
+import { HttpError } from "../../../../lib/HttpError"
 
 const GetAssetByIDHandler: NextApiHandler = async (req, res) => {
   if (req.method !== "GET") {
@@ -14,7 +15,9 @@ const GetAssetByIDHandler: NextApiHandler = async (req, res) => {
 
       res.json(assetRes.body)
     } catch (error) {
-      res.status((error as any).statusCode ?? 500).end()
+      console.log("[GetAssetByIDHandler]", error)
+      const err = error as HttpError
+      res.status(err.statusCode ?? 500).json(err.body)
     }
   }
 }

--- a/pages/api/assets/[id]/overview.ts
+++ b/pages/api/assets/[id]/overview.ts
@@ -3,6 +3,7 @@ import xss from "xss"
 
 import { config } from "../../../../config"
 import { HttpClient } from "../../../../lib/HttpClient"
+import { HttpError } from "../../../../lib/HttpError"
 
 const GetAssetOverview: NextApiHandler = async (req, res) => {
   if (req.method !== "GET") {
@@ -25,7 +26,9 @@ const GetAssetOverview: NextApiHandler = async (req, res) => {
 
       res.json(attrs)
     } catch (error) {
-      res.status((error as any).statusCode ?? 500).end()
+      console.log("[GetAssetOverviewHandler]", error)
+      const err = error as HttpError
+      res.status(err.statusCode ?? 500).json(err.body)
     }
   }
 }

--- a/pages/api/assets/[id]/responsibilities.ts
+++ b/pages/api/assets/[id]/responsibilities.ts
@@ -2,6 +2,7 @@ import { NextApiHandler } from "next"
 
 import { config } from "../../../../config"
 import { HttpClient } from "../../../../lib/HttpClient"
+import { HttpError } from "../../../../lib/HttpError"
 
 const AssetResponsibilitiesHandler: NextApiHandler = async (req, res) => {
   if (req.method !== "GET") {
@@ -44,7 +45,8 @@ const AssetResponsibilitiesHandler: NextApiHandler = async (req, res) => {
       }
     } catch (error) {
       console.log("[AssetResponsibilitiesHandler]", error)
-      res.status((error as any).statusCode ?? 500).end()
+      const err = error as HttpError
+      res.status(err.statusCode ?? 500).json(err.body)
     }
   }
 }

--- a/pages/api/communities.ts
+++ b/pages/api/communities.ts
@@ -2,30 +2,37 @@ import { NextApiHandler } from "next"
 
 import { config } from "../../config"
 import { HttpClient } from "../../lib/HttpClient"
+import { HttpError } from "../../lib/HttpError"
 
 const CommunitiesHandler: NextApiHandler = async (req, res) => {
   switch (req.method) {
     case "GET": {
-      const allComunities = await HttpClient.get<Collibra.PagedCommunityResponse>(`${config.COLLIBRA_BASE_URL}/communities`, {
-        headers: { authorization: req.headers.authorization },
-        query: {
-          name: "equinor",
-          nameMatchMode: "ANYWHERE",
-        },
-      })
+      try {
+        const allComunities = await HttpClient.get<Collibra.PagedCommunityResponse>(`${config.COLLIBRA_BASE_URL}/communities`, {
+          headers: { authorization: req.headers.authorization },
+          query: {
+            name: "equinor",
+            nameMatchMode: "ANYWHERE",
+          },
+        })
 
-      const equinorCommunity = allComunities.body?.results[0]
+        const equinorCommunity = allComunities.body?.results[0]
 
-      if (!equinorCommunity) {
-        return res.status(500).end()
+        if (!equinorCommunity) {
+          return res.status(500).end()
+        }
+
+        const communities = await HttpClient.get<Collibra.PagedCommunityResponse>(`${config.COLLIBRA_BASE_URL}/communities`, {
+          headers: { authorization: req.headers.authorization },
+          query: { parentId: equinorCommunity.id },
+        })
+
+        return res.json(communities.body?.results)
+      } catch (error) {
+        console.log("[CommunitiesHandler]", error)
+        const err = error as HttpError
+        return res.status(err.statusCode ?? 500).json(err.body)
       }
-
-      const communities = await HttpClient.get<Collibra.PagedCommunityResponse>(`${config.COLLIBRA_BASE_URL}/communities`, {
-        headers: { authorization: req.headers.authorization },
-        query: { parentId: equinorCommunity.id },
-      })
-
-      return res.json(communities.body?.results)
     }
     default:
       return res.status(405).end()

--- a/pages/api/popular.ts
+++ b/pages/api/popular.ts
@@ -2,6 +2,7 @@ import type { NextApiHandler } from "next"
 
 import { config } from "../../config"
 import { HttpClient } from "../../lib/HttpClient"
+import { HttpError } from "../../lib/HttpError"
 
 type PopularAsset = Collibra.Asset & Pick<Collibra.NavigationStatistic, "numberOfViews">
 
@@ -59,7 +60,8 @@ const PopularAssetsHandler: NextApiHandler = async (req, res) => {
     res.json(dataProducts)
   } catch (error) {
     console.log("[PopularAssetsHandler]", error)
-    res.status(500).end()
+    const err = error as HttpError
+    res.status(err.statusCode ?? 500).json(err.body)
   }
 }
 

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -4,7 +4,8 @@ import { NextApiHandler } from "next"
 import xss from "xss"
 
 import { config } from "../../config"
-import { HttpClient, HttpError } from "../../lib/HttpClient"
+import { HttpClient } from "../../lib/HttpClient"
+import { HttpError } from "../../lib/HttpError"
 
 const SearchHandler: NextApiHandler = async (req, res) => {
   if (req.method !== "GET") {
@@ -67,8 +68,9 @@ const SearchHandler: NextApiHandler = async (req, res) => {
         results,
       })
     } catch (error) {
+      console.log("[SearchHandler]", error)
       const err = error as HttpError
-      res.status(err.statusCode ?? 500).send(err.body)
+      res.status(err.statusCode ?? 500).json(err.body)
     }
   }
 }


### PR DESCRIPTION
Backend now forwards status codes >= 400 from Collibra. If a status code is not present in the HttpError object, we fall back to 500.

Resolves #50 