### PR TITLE
Ah 149 get rights to use

### DIFF
--- a/components/Banner/Banner.tsx
+++ b/components/Banner/Banner.tsx
@@ -11,28 +11,20 @@ type Props = {
 }
 
 const BannerContainer = styled.div<{ variant: string }>`
-    background-color: ${({ variant }) => (variant === "danger" ? tokens.colors.ui.background__danger.rgba : tokens.colors.ui.background__warning.rgba)};
-    display: flex;
-    justify-content: start;
-    gap: 1rem;
-    padding: 1.5rem;
+  background-color: ${({ variant }) => (variant === "danger" ? tokens.colors.ui.background__danger.rgba : tokens.colors.ui.background__warning.rgba)};
+  display: flex;
+  justify-content: start;
+  gap: 1rem;
+  padding: 1.5rem;
 `
 
-const BannerIcon = styled.div`
-    line-height:0;
-`
-const TextWrapper = styled.div`
-display: flex;
-align-items: center;
-`
 export const Banner: FunctionComponent<Props> = ({ variant, children, ...rest }) => (
   // eslint-disable-next-line react/jsx-props-no-spreading
   <BannerContainer variant={variant} {...rest}>
-    <BannerIcon>
-      <Icon color={variant === "danger" ? tokens.colors.interactive.danger__text.rgba : tokens.colors.interactive.warning__text.rgba} data={warning_filled} />
-    </BannerIcon>
-    <TextWrapper>
+    <Icon color={variant === "danger" ? tokens.colors.interactive.danger__text.rgba : tokens.colors.interactive.warning__text.rgba} data={warning_filled} />
+
+    <div>
       {children}
-    </TextWrapper>
+    </div>
   </BannerContainer>
 )

--- a/components/Banner/Banner.tsx
+++ b/components/Banner/Banner.tsx
@@ -12,10 +12,11 @@ type Props = {
 
 const BannerContainer = styled.div<{ variant: string }>`
   background-color: ${({ variant }) => (variant === "danger" ? tokens.colors.ui.background__danger.rgba : tokens.colors.ui.background__warning.rgba)};
-  display: flex;
-  justify-content: start;
+  display: grid;
+  grid-template-columns: auto 1fr;
   gap: 1rem;
-  padding: 1.5rem;
+  padding: 1rem;
+  border-radius: 4px;
 `
 
 export const Banner: FunctionComponent<Props> = ({ variant, children, ...rest }) => (

--- a/pages/checkout/terms.tsx
+++ b/pages/checkout/terms.tsx
@@ -42,7 +42,7 @@ const ButtonContainer = styled.div`
 `
 
 type Props = {
-  assetId: string
+  assetId?: string | null
   rightsToUse?: {
     name: string
     value: string
@@ -66,7 +66,7 @@ const CheckoutTermsView: NextPage<Props> = ({ assetId, rightsToUse }) => {
   const onAcceptTerms = () => {
     setCheckoutData({
       ...checkoutData,
-      assetId,
+      assetId: assetId ?? "",
       terms: { ...checkoutData.terms, termsAccepted: !hasAcceptedTerms },
     })
   }
@@ -74,7 +74,7 @@ const CheckoutTermsView: NextPage<Props> = ({ assetId, rightsToUse }) => {
   return (
     <>
       <Container>
-        <CheckoutWizard assetId={assetId}>
+        <CheckoutWizard assetId={assetId ?? ""}>
           {!assetId ? <NoAsset />
             : (
               <>
@@ -123,7 +123,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, query }) => 
   // We should query for terms and the asset title and evaluate how much this will
   // affect TTFB
 
-  const defaultPageProps: Props = { assetId: id as string }
+  const defaultPageProps: Props = { assetId: id as string || null }
 
   const token = await getToken({ req })
 

--- a/pages/checkout/terms.tsx
+++ b/pages/checkout/terms.tsx
@@ -32,12 +32,6 @@ const CheckboxContainer = styled.div`
   }
 `
 
-const TypographyHeader = styled(Typography)`
-  font-weight: 500;
-  font-size: 1.125rem;
-  line-height: 1.5rem;
-`
-
 const ButtonContainer = styled.div`
   display: flex;
   justify-content: flex-end;
@@ -92,7 +86,7 @@ const CheckoutTermsView: NextPage<Props> = ({ assetId, rightsToUse }) => {
                   />
                 </IngressContainer>
                 <Banner variant="danger">
-                  <TypographyHeader>{rightsToUse?.name}</TypographyHeader>
+                  <Typography variant="h5" as="h2">{rightsToUse?.name}</Typography>
                   <Typography dangerouslySetInnerHTML={{ __html: rightsToUse?.value! }} />
                 </Banner>
                 <CheckboxContainer>


### PR DESCRIPTION
Resolves #149

# To do
- [x] Decide whether or not to keep using `getServerSideProps` or move the logic to an API route
  - Note from author: Since we need to perform five(!) API requests, doing so in `getServerSideProps` negatively impacts time to first byte.