### PR TITLE
Improved user feedback when we can't find terms and conditions

### DIFF
--- a/lib/errors/ClientError.ts
+++ b/lib/errors/ClientError.ts
@@ -2,7 +2,7 @@ import { __Error__ } from "./__Error__"
 import { ErrSource } from "./types"
 
 export class ClientError extends __Error__ {
-  constructor(message: string, code: string) {
-    super(message, ErrSource.Client, code)
+  constructor(message: string, code: string, details?: any) {
+    super(message, ErrSource.Client, code, details)
   }
 }

--- a/lib/errors/ClientError.ts
+++ b/lib/errors/ClientError.ts
@@ -1,0 +1,8 @@
+import { __Error__ } from "./__Error__"
+import { ErrSource } from "./types"
+
+export class ClientError extends __Error__ {
+  constructor(message: string, code: string) {
+    super(message, ErrSource.Client, code)
+  }
+}

--- a/lib/errors/ExternalError.ts
+++ b/lib/errors/ExternalError.ts
@@ -1,0 +1,12 @@
+import { __Error__ } from "./__Error__"
+import { ErrSource } from "./types"
+
+/**
+ * ExternalError should be thrown when for example a call to an
+ * external service returns unexpected data or fails outright.
+ */
+export class ExternalError extends __Error__ {
+  constructor(message: string, code: string) {
+    super(message, ErrSource.External, code)
+  }
+}

--- a/lib/errors/ExternalError.ts
+++ b/lib/errors/ExternalError.ts
@@ -6,7 +6,7 @@ import { ErrSource } from "./types"
  * external service returns unexpected data or fails outright.
  */
 export class ExternalError extends __Error__ {
-  constructor(message: string, code: string) {
-    super(message, ErrSource.External, code)
+  constructor(message: string, code: string, details?: any) {
+    super(message, ErrSource.External, code, details)
   }
 }

--- a/lib/errors/InternalError.ts
+++ b/lib/errors/InternalError.ts
@@ -1,8 +1,0 @@
-import { __Error__ } from "./__Error__"
-import { ErrSource } from "./types"
-
-export class InternalError extends __Error__ {
-  constructor(message: string, code: string, details?: any) {
-    super(message, ErrSource.Internal, code, details)
-  }
-}

--- a/lib/errors/InternalError.ts
+++ b/lib/errors/InternalError.ts
@@ -1,0 +1,8 @@
+import { __Error__ } from "./__Error__"
+import { ErrSource } from "./types"
+
+export class InternalError extends __Error__ {
+  constructor(message: string, code: string) {
+    super(message, ErrSource.Internal, code)
+  }
+}

--- a/lib/errors/InternalError.ts
+++ b/lib/errors/InternalError.ts
@@ -2,7 +2,7 @@ import { __Error__ } from "./__Error__"
 import { ErrSource } from "./types"
 
 export class InternalError extends __Error__ {
-  constructor(message: string, code: string) {
-    super(message, ErrSource.Internal, code)
+  constructor(message: string, code: string, details?: any) {
+    super(message, ErrSource.Internal, code, details)
   }
 }

--- a/lib/errors/__Error__.ts
+++ b/lib/errors/__Error__.ts
@@ -1,11 +1,13 @@
 import { ErrSource } from "./types"
 
 export class __Error__ extends Error {
-  private code: string
+  code: string
+  details?: any
 
-  constructor(message: string, source: ErrSource, code: string) {
+  constructor(message: string, source: ErrSource, code: string, details?: any) {
     super(message)
-    this.code = `E_${source}.${code}`
+    this.code = `E${source}${code}`
+    this.details = details
   }
 
   toString(): string {

--- a/lib/errors/__Error__.ts
+++ b/lib/errors/__Error__.ts
@@ -1,0 +1,18 @@
+import { ErrSource } from "./types"
+
+export class __Error__ extends Error {
+  private code: string
+
+  constructor(message: string, source: ErrSource, code: string) {
+    super(message)
+    this.code = `E_${source}.${code}`
+  }
+
+  toString(): string {
+    return `${this.code}: ${this.message}`
+  }
+
+  toJSON(): string {
+    return this.toString()
+  }
+}

--- a/lib/errors/codes.ts
+++ b/lib/errors/codes.ts
@@ -1,0 +1,3 @@
+export const ERR_CODES = Object.freeze({
+  INVALID_DATA: "001",
+})

--- a/lib/errors/codes.ts
+++ b/lib/errors/codes.ts
@@ -1,3 +1,4 @@
 export const ERR_CODES = Object.freeze({
   INVALID_DATA: "001",
+  MISSING_DATA: "002",
 })

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,2 +1,3 @@
 export { ERR_CODES } from "./codes"
 export { ClientError } from "./ClientError"
+export { ExternalError } from "./ExternalError"

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,1 +1,2 @@
 export { ERR_CODES } from "./codes"
+export { ClientError } from "./ClientError"

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,3 +1,4 @@
 export { ERR_CODES } from "./codes"
 export { ClientError } from "./ClientError"
 export { ExternalError } from "./ExternalError"
+export { InternalError } from "./InternalError"

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,0 +1,1 @@
+export { ERR_CODES } from "./codes"

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,4 +1,3 @@
 export { ERR_CODES } from "./codes"
 export { ClientError } from "./ClientError"
 export { ExternalError } from "./ExternalError"
-export { InternalError } from "./InternalError"

--- a/lib/errors/types.ts
+++ b/lib/errors/types.ts
@@ -1,0 +1,5 @@
+export enum ErrSource {
+  Client,
+  External,
+  Internal,
+}

--- a/lib/errors/types.ts
+++ b/lib/errors/types.ts
@@ -1,5 +1,4 @@
 export enum ErrSource {
   Client,
   External,
-  Internal,
 }

--- a/locales/english.json
+++ b/locales/english.json
@@ -26,6 +26,8 @@
   "terms.ingress": "<p>The agreement between you and the data provider is created by these terms and conditions.</p><p>Access to this Data Product requires you to meet the following criteria.</p>",
   "terms.acceptLabel": "I accept the terms and conditions",
   "terms.accept.errorMessage": "You must accept the terms and conditions",
+  "terms.error.E1002.bannerMessage": "Unfortunately, we were unable to get the Terms and Conditions for this data product from Collibra.",
+  "terms.error.E1002.additional": "Because accepting Terms and Conditions is a requirement to get access to a data product, we are unable to let you proceed with the checkout.",
   "checkout.access.exampleBody": "As a [role] I want [description of what you want to do with the data product], so that [description of why you need the data product]",
   "checkout.access.descriptionInput.label": "Why do you need access? (max. {maxLength} characters)",
   "checkout.access.descriptionInput.errorMessage": "This field is required and you must add at least {minLength} characters",

--- a/pages/checkout/terms.tsx
+++ b/pages/checkout/terms.tsx
@@ -80,10 +80,7 @@ const CheckoutTermsView: NextPage<Props> = ({ asset, error, rightsToUse }) => {
 
   useEffect(() => {
     if (asset) {
-      setCheckoutData({
-        ...checkoutData,
-        asset: { id: asset.id, name: asset.name },
-      })
+      setCheckoutData({ asset: { id: asset.id, name: asset.name } })
     }
   }, [asset])
 
@@ -167,7 +164,6 @@ const CheckoutTermsView: NextPage<Props> = ({ asset, error, rightsToUse }) => {
     asset,
     formError,
     hasAcceptedTerms,
-    intl,
     rightsToUse,
     checkoutData,
   ])
@@ -186,14 +182,8 @@ const CheckoutTermsView: NextPage<Props> = ({ asset, error, rightsToUse }) => {
 
 export const getServerSideProps: GetServerSideProps = async ({ req, query }) => {
   const { id } = query
-  // @TODO when we have server side token handle the case of no id or no data
-  // We should query for terms and the asset title and evaluate how much this will
-  // affect TTFB
-
   const defaultPageProps: Props = { asset: null }
-
   const token = await getToken({ req })
-
   const authorization = `Bearer ${token!.accessToken}`
 
   try {

--- a/pages/checkout/terms.tsx
+++ b/pages/checkout/terms.tsx
@@ -86,7 +86,13 @@ const CheckoutTermsView: NextPage<Props> = ({ asset, error, rightsToUse }) => {
 
   useEffect(() => {
     if (asset) {
-      setCheckoutData({ asset: { id: asset.id, name: asset.name } })
+      setCheckoutData({
+        asset: {
+          ...(checkoutData.asset ?? {}),
+          id: asset.id,
+          name: asset.name,
+        },
+      })
     }
   }, [asset])
 


### PR DESCRIPTION
- Adds utility classes for three potential error "sources"
  - `ClientError` - any error caused by the user
  - `ExternalError` - any error caused by any third party (i.e. external APIs such as data sources)
- Introduces a schema for error codes: `EN000` where `N` is an enum denoting the source of the error, and the last three digits denote the type of error.
  - **0:** Errors caused by the user
  - **1:** Errors caused by an external resource
- Forwards the error code and message from `getServerSideProps` to the view
---
Resolves [AB#78408](https://dev.azure.com/EquinorASA/d02c350d-092d-41bf-a812-f05d5d8ad1b0/_workitems/edit/78408), resolves [AB#78740](https://dev.azure.com/EquinorASA/d02c350d-092d-41bf-a812-f05d5d8ad1b0/_workitems/edit/78740), resolves [AB#78741](https://dev.azure.com/EquinorASA/d02c350d-092d-41bf-a812-f05d5d8ad1b0/_workitems/edit/78741)