### PR TITLE
Prevent checkout of unapproved assets

### DIFF
--- a/lib/errors/codes.ts
+++ b/lib/errors/codes.ts
@@ -1,4 +1,5 @@
 export const ERR_CODES = Object.freeze({
   INVALID_DATA: "001",
   MISSING_DATA: "002",
+  ASSET_NOT_APPROVED: "003",
 })

--- a/locales/english.json
+++ b/locales/english.json
@@ -29,6 +29,7 @@
   "terms.ingress": "<p>The agreement between you and the data provider is created by these terms and conditions.</p><p>Access to this Data Product requires you to meet the following criteria.</p>",
   "terms.acceptLabel": "I accept the terms and conditions",
   "terms.accept.errorMessage": "You must accept the terms and conditions",
+  "terms.error.E0003.bannerMessage": "This asset is not approved for checkout.",
   "terms.error.E1002.bannerMessage": "Unfortunately, we were unable to get the Terms and Conditions for this data product from Collibra.",
   "terms.error.E1002.additional": "Because accepting Terms and Conditions is a requirement to get access to a data product, we are unable to let you proceed with the checkout.",
   "checkout.access.exampleBody": "As a [role] I want [description of what you want to do with the data product], so that [description of why you need the data product]",

--- a/model/Asset.ts
+++ b/model/Asset.ts
@@ -2,6 +2,7 @@ type AssetInit = {
   id: string
   name: string
   description?: string
+  approved?: boolean
   domain?: string
   updateFrequency?: string
   tags?: DataMarketplace.Tag[]
@@ -13,6 +14,7 @@ export class Asset implements DataMarketplace.Asset {
   id: string
   name: string
   description: Optional<string>
+  approved: boolean
   domain: Optional<string>
   updateFrequency: Optional<string>
   tags: Optional<DataMarketplace.Tag[]>
@@ -23,6 +25,7 @@ export class Asset implements DataMarketplace.Asset {
     this.id = init.id
     this.name = init.name
     this.description = init.description || null
+    this.approved = init.approved ?? false
     this.domain = init.domain || null
     this.updateFrequency = init.updateFrequency || null
     this.tags = init.tags || null
@@ -37,6 +40,7 @@ export class Asset implements DataMarketplace.Asset {
       id: asset.id,
       name: asset.name!,
       domain: asset.domain.name!,
+      approved: asset.status.name === "Approved",
       createdAt: asset.createdOn,
       updatedAt: asset.lastModifiedOn,
     })

--- a/model/Asset.ts
+++ b/model/Asset.ts
@@ -2,8 +2,8 @@ type AssetInit = {
   id: string
   name: string
   description?: string
-  approved?: boolean
-  type?: string
+  approved: boolean
+  type: string
   domain?: string
   updateFrequency?: string
   tags?: DataMarketplace.Tag[]

--- a/model/Asset.ts
+++ b/model/Asset.ts
@@ -3,6 +3,7 @@ type AssetInit = {
   name: string
   description?: string
   approved?: boolean
+  type?: string
   domain?: string
   updateFrequency?: string
   tags?: DataMarketplace.Tag[]
@@ -15,6 +16,7 @@ export class Asset implements DataMarketplace.Asset {
   name: string
   description: Optional<string>
   approved: boolean
+  type: Optional<string>
   domain: Optional<string>
   updateFrequency: Optional<string>
   tags: Optional<DataMarketplace.Tag[]>
@@ -26,6 +28,7 @@ export class Asset implements DataMarketplace.Asset {
     this.name = init.name
     this.description = init.description || null
     this.approved = init.approved ?? false
+    this.type = init.type || null
     this.domain = init.domain || null
     this.updateFrequency = init.updateFrequency || null
     this.tags = init.tags || null
@@ -41,8 +44,13 @@ export class Asset implements DataMarketplace.Asset {
       name: asset.name!,
       domain: asset.domain.name!,
       approved: asset.status.name === "Approved",
+      type: asset.type.name.toUpperCase().replaceAll(/\s/g, "_"),
       createdAt: asset.createdOn,
       updatedAt: asset.lastModifiedOn,
     })
+  }
+
+  static isDataProduct(asset: Asset): boolean {
+    return asset.type === "DATA_PRODUCT"
   }
 }

--- a/pages/checkout/terms.tsx
+++ b/pages/checkout/terms.tsx
@@ -31,6 +31,7 @@ import { defaultComponents } from "htmlParsing/portableText"
 import { getPortableText } from "htmlParsing/richTextContent"
 import { ClientError, ERR_CODES, ExternalError } from "lib/errors"
 import { __Error__ } from "lib/errors/__Error__"
+import { Asset } from "model/Asset"
 import { makeCollibraService } from "services"
 import {
   getAssetAttributes,
@@ -214,7 +215,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, query }) => 
   try {
     const asset = await makeCollibraServiceRequest(getAssetByID)(id)
 
-    if (!asset.approved) {
+    if (!asset.approved || !Asset.isDataProduct(asset)) {
       throw new ClientError(`Data product ${id} not approved`, ERR_CODES.ASSET_NOT_APPROVED)
     }
 


### PR DESCRIPTION
Displays an error message if the asset the user tries to checkout
- an unapproved data product
- an asset that isn't a data product

Resolves [AB#81116](https://dev.azure.com/EquinorASA/d02c350d-092d-41bf-a812-f05d5d8ad1b0/_workitems/edit/81116)