### PR TITLE
refactor: Make NEXT_PUBLIC_COLLIBRA_BASE_URL non-public

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,5 @@
 # === Collibra ===
-NEXT_PUBLIC_COLLIBRA_BASE_URL=
+COLLIBRA_BASE_URL=
 NEXT_PUBLIC_COLLIBRA_FIRST_TIME_VISITOR=
 
 # === MS Application Insight ===

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -73,7 +73,7 @@ jobs:
         run: |
           npm run build
         env:
-          NEXT_PUBLIC_COLLIBRA_BASE_URL: ${{ secrets.NEXT_PUBLIC_COLLIBRA_BASE_URL }}
+          COLLIBRA_BASE_URL: ${{ secrets.COLLIBRA_BASE_URL }}
       - name: log-errors-to-slack
         uses: act10ns/slack@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN npm ci
 
 FROM node:lts-alpine AS builder
 WORKDIR /opt/app
-ENV NEXT_PUBLIC_COLLIBRA_BASE_URL https://equinor-test.collibra.com/rest/2.0
+ENV COLLIBRA_BASE_URL https://equinor-test.collibra.com/rest/2.0
 ENV NEXT_PUBLIC_APP_INSIGHTS_CONNECTION_STRING InstrumentationKey=e4d53b02-e08f-45e0-8632-7a066b44bc4f;IngestionEndpoint=https://northeurope-2.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/
 ENV NEXT_PUBLIC_COLLIBRA_FIRST_TIME_VISITOR https://equinor-test.collibra.com
 

--- a/config.ts
+++ b/config.ts
@@ -1,6 +1,6 @@
 export const config = Object.freeze({
   BASE_URL: process.env.BASE_URL ?? "http://localhost:3000",
-  COLLIBRA_BASE_URL: process.env.NEXT_PUBLIC_COLLIBRA_BASE_URL ?? "",
+  COLLIBRA_BASE_URL: process.env.COLLIBRA_BASE_URL ?? "",
   COLLIBRA_FIRST_TIME_VISITOR: process.env.NEXT_PUBLIC_COLLIBRA_FIRST_TIME_VISITOR ?? "",
   INSIGHTS_CONNECTION_STRING: process.env.NEXT_PUBLIC_APP_INSIGHTS_CONNECTION_STRING ?? "",
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -24,7 +24,7 @@ const nextConfig = {
   rewrites: async () => [
     {
       source: "/api/collibra/:path*",
-      destination: `${getEnvironmentVariable("NEXT_PUBLIC_COLLIBRA_BASE_URL")}/:path*`,
+      destination: `${getEnvironmentVariable("COLLIBRA_BASE_URL")}/:path*`,
     },
   ],
 }

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -26,7 +26,7 @@ spec:
           variables:
             BASE_URL: https://web-data-marketplace-test.radix.equinor.com/
             AUTH_SCOPE: https://equinor-test.collibra.com/user_impersonation
-            NEXT_PUBLIC_COLLIBRA_BASE_URL: https://equinor-test.collibra.com/rest/2.0
+            COLLIBRA_BASE_URL: https://equinor-test.collibra.com/rest/2.0
             NEXT_PUBLIC_COLLIBRA_FIRST_TIME_VISITOR: https://equinor-test.collibra.com
         - environment: test
           resources:
@@ -39,7 +39,7 @@ spec:
           variables:
             BASE_URL: https://web-data-marketplace-test.radix.equinor.com
             AUTH_SCOPE: https://equinor-test.collibra.com/user_impersonation
-            NEXT_PUBLIC_COLLIBRA_BASE_URL: https://equinor-test.collibra.com/rest/2.0
+            COLLIBRA_BASE_URL: https://equinor-test.collibra.com/rest/2.0
             NEXT_PUBLIC_COLLIBRA_FIRST_TIME_VISITOR: https://equinor-test.collibra.com
       variables:
         NEXT_PUBLIC_APP_INSIGHTS_CONNECTION_STRING: InstrumentationKey=e4d53b02-e08f-45e0-8632-7a066b44bc4f;IngestionEndpoint=https://northeurope-2.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/


### PR DESCRIPTION
Since `COLLIBRA_BASE_URL` is only used server side, there's no need for it to keep the `NEXT_PUBLIC_` prefix.

**IMPORTANT NOTE**
This change requires an update to GitHub secrets to build. Not sure whether we want to do this before or after this is merged.

Resolves [AB#88795](https://dev.azure.com/EquinorASA/d02c350d-092d-41bf-a812-f05d5d8ad1b0/_workitems/edit/88795)