### PR TITLE
Fix access token refresh

### DIFF
--- a/collibra.d.ts
+++ b/collibra.d.ts
@@ -1,7 +1,521 @@
 declare namespace Collibra {
+  type ResourceType =
+    | "View"
+    | "Asset"
+    | "Community"
+    | "Domain"
+    | "AssetType"
+    | "DomainType"
+    | "Status"
+    | "User"
+    | "ClassificationMatch"
+    | "UserGroup"
+    | "Attribute"
+    | "StringAttribute"
+    | "ScriptAttribute"
+    | "BooleanAttribute"
+    | "DateAttribute"
+    | "NumericAttribute"
+    | "SingleValueListAttribute"
+    | "MultiValueListAttribute"
+    | "Comment"
+    | "Attachment"
+    | "Responsibility"
+    | "Workflow"
+    | "Job"
+    | "Relation"
+    | "RelationType"
+    | "ComplexRelation"
+    | "ComplexRelationType"
+    | "ArticulationRule"
+    | "Assignment"
+    | "Scope"
+    | "RelationTrace"
+    | "ValidationRule"
+    | "DataQualityRule"
+    | "DataQualityMetric"
+    | "Address"
+    | "InstantMessagingAccount"
+    | "Email"
+    | "PhoneNumber"
+    | "Website"
+    | "Activity"
+    | "FormProperty"
+    | "WorkflowTask"
+    | "ActivityChange"
+    | "WorkflowInstance"
+    | "Role"
+    | "AttributeType"
+    | "BooleanAttributeType"
+    | "DateAttributeType"
+    | "DateTimeAttributeType"
+    | "MultiValueListAttributeType"
+    | "NumericAttributeType"
+    | "ScriptAttributeType"
+    | "SingleValueListAttributeType"
+    | "StringAttributeType"
+    | "ViewSharingRule"
+    | "ViewAssignmentRule"
+    | "JdbcDriverFile"
+    | "JdbcDriver"
+    | "JdbcIngestionProperties"
+    | "CsvIngestionProperties"
+    | "ExcelIngestionProperties"
+    | "ConnectionStringParameter"
+    | "AssignedCharacteristicType"
+    | "Notification"
+    | "Tag"
+    | "ComplexRelationLegType"
+    | "ComplexRelationAttributeType"
+    | "ComplexRelationLeg"
+    | "BaseDataType"
+    | "AdvancedDataType"
+    | "DiagramPicture"
+    | "DiagramPictureSharingRule"
+    | "DiagramPictureAssignmentRule"
+    | "Rating"
+    | "Classification"
+    | "PhysicalDataConnector"
+    | "Context"
+
+  type ResourceReference = {
+    id: string
+    resourceType: ResourceType
+  }
+
+  type NamedResourceReference = ResourceReference & {
+    name: string
+  }
+
+  type Resource = ResourceReference & {
+    createdBy: string
+    createdOn: number
+    lastModifiedBy: string
+    lastModifiedOn: number
+    system: boolean
+  }
+
+  type NamedResource = Resource & {
+    name?: string | null
+  }
+
+  export type Attribute = Resource & {
+    asset: NamedResourceReference
+    value: any
+    type: NamedResourceReference
+  }
+
+  export type Asset = NamedResource & {
+    displayName: string
+    articulationScore: number
+    excludedFromAutoHyperlinking: boolean
+    domain: NamedResourceReference
+    type: NamedResourceReference
+    status: NamedResourceReference
+    avgRating: number
+    ratingsCount: number
+  }
+
+  export type AssetWithAttributes = Asset & {
+    attributes: Attribute[]
+  }
+
+  export type Responsibility = Resource & {
+    role: NamedResourceReference
+    baseResource: ResourceReference
+    owner: ResourceReference
+  }
+
+  type Email = Resource & {
+    emailAddress: string
+  }
+
+  type PhoneNumber = Resource & {
+    type: "FAX" | "MOBILE" | "OTHER" | "PAGER" | "PRIVATE" | "WORK"
+    phoneNumber: string
+  }
+
+  type InstantMessagingAccount = Resource & {
+    account: string
+    type: "AOL" | "GTALK" | "ICQ" | "JABBER" | "LIVE_MESSENGER" | "SKYPE" | "YAHOO_MESSENGER"
+  }
+
+  type Website = Resource & {
+    url: string
+    type: "FACEBOOK" | "LINKEDIN" | "MYSPACE" | "TWITTER" | "WEBSITE"
+  }
+
+  type Address = Resource & {
+    city: string
+    street: string
+    number: string
+    state: string
+    country: string
+    postalCode: string
+    type: "HOME" | "WORK"
+  }
+
+  export type User = Resource & {
+    userName: string
+    firstName: string
+    lastName: string
+    emailAddress: string
+    gender: "MALE" | "FEMALE" | "UNKNOWN"
+    language: string
+    additionalEmailAddresses: Email[]
+    phoneNumbers: PhoneNumber[]
+    instantMessagingAccounts: InstantMessagingAccount[]
+    websites: Website[]
+    addresses: Address[]
+    activated: boolean
+    enabled: boolean
+    ldapUser: boolean
+    userSource: "INTERNAL" | "LDAP" | "SSO"
+    guestUser: boolean
+    apiUser: boolean
+    licenseType: "CONSUMER" | "AUTHOR"
+  }
+
+  export type NavigationStatistic = {
+    assetId: string
+    name: string
+    numberOfViews: number
+    lastViewedDate: number
+  }
+
   export type Community = Resource & {
     name: string
     description: string
+  }
+
+  export type Domain = NamedResource & {
+    description: string
+    type: NamedResourceReference
+    community: NamedResourceReference
+    excludedFromAutoHyperlinking: boolean
+  }
+
+  export type Status = NamedResource & {
+    description: string
+  }
+
+  type SymbolData = {
+    color: string
+    symbolType: "NONE" | "ICON_CODE" | "ACRONYM_CODE"
+    iconCode: string
+    acronymCode: string
+  }
+
+  export type AssetType = NamedResource & {
+    description: string
+    parent: NamedResourceReference
+    symbolData: SymbolData
+    displayNameEnabled: boolean
+    ratingEnabled: boolean
+  }
+
+  export type RelationType = Resource & {
+    resourceType: ResourceType
+    sourceType: NamedResourceReference
+    targetType: NamedResourceReference
+    role: string
+    coRole: string
+    description: string
+  }
+
+  export type Relation = Resource & {
+    resourceType: ResourceType
+    source: NamedResourceReference
+    target: NamedResourceReference
+    type: ResourceReference
+    startingDate: number
+    endingDate: number
+  }
+
+  export type StartWorkflowInstanceRequest = {
+    workflowDefinitionId: string
+    businessItemIds: string[]
+    businessItemType: "ASSET" | "DOMAIN" | "COMMUNITY" | "GLOBAL"
+    formProperties: Record<string, any>
+    guestUserId: string
+    sendNotification: boolean
+  }
+
+  type Permission =
+    | "EDGE"
+    | "EDGE_SITE_CONNECT"
+    | "EDGE_SITE_MANAGE"
+    | "EDGE_SITE_ADMINISTER"
+    | "EDGE_INTEGRATION_CAPABILITY_MANAGE"
+    | "EDGE_VIEW_CONNECTIONS_AND_CAPABILITIES"
+    | "EDGE_VIEW_LOGS"
+    | "ASSET_GRID_ADMINISTRATION"
+    | "ATTACHMENT_ADD"
+    | "ATTACHMENT_CHANGE"
+    | "ATTACHMENT_REMOVE"
+    | "COMMENT_ADD"
+    | "COMMENT_CHANGE"
+    | "COMMENT_REMOVE"
+    | "RATING_ADD"
+    | "RATING_CHANGE"
+    | "RATING_REMOVE"
+    | "COMMUNITY_ADD"
+    | "COMMUNITY_CHANGE"
+    | "COMMUNITY_REMOVE"
+    | "COMMUNITY_CONFIGURE_EXTERNAL_SYSTEM"
+    | "COMMUNITY_RESPONSIBILITY_ADD"
+    | "COMMUNITY_RESPONSIBILITY_CHANGE"
+    | "COMMUNITY_RESPONSIBILITY_REMOVE"
+    | "DOMAIN_ADD"
+    | "DOMAIN_CHANGE"
+    | "DOMAIN_REMOVE"
+    | "DOMAIN_RESPONSIBILITY_ADD"
+    | "DOMAIN_RESPONSIBILITY_CHANGE"
+    | "DOMAIN_RESPONSIBILITY_REMOVE"
+    | "WORKFLOW_MANAGE"
+    | "WORKFLOW_DESIGNER_ACCESS"
+    | "ASSET_ADD"
+    | "ASSET_CHANGE"
+    | "ASSET_REMOVE"
+    | "ASSET_STATUS_CHANGE"
+    | "ASSET_TYPE_CHANGE"
+    | "ASSET_TAG_CHANGE"
+    | "ASSET_ATTRIBUTE_ADD"
+    | "ASSET_ATTRIBUTE_CHANGE"
+    | "ASSET_ATTRIBUTE_REMOVE"
+    | "ASSET_RESPONSIBILITY_ADD"
+    | "ASSET_RESPONSIBILITY_CHANGE"
+    | "ASSET_RESPONSIBILITY_REMOVE"
+    | "VIEW_PERMISSIONS_CHANGE"
+    | "BUSINESS_SEMANTICS_GLOSSARY"
+    | "REFERENCE_DATA_MANAGER"
+    | "DATA_STEWARDSHIP_MANAGER"
+    | "SYSTEM_ADMINISTRATION"
+    | "USER_ADMINISTRATION"
+    | "WORKFLOW_ADMINISTRATION"
+    | "DATA_HELPDESK"
+    | "POLICY_MANAGER"
+    | "DATA_DICTIONARY"
+    | "CATALOG"
+    | "WORKFLOW_MANAGE_ALL"
+    | "WORKFLOW_MESSAGE_EVENTS_USE"
+    | "VIEW_PERMISSIONS_VIEW_ALL"
+    | "VIEW_MANAGE"
+    | "VIEW_SHARE"
+    | "VIEW_MANAGE_ALL"
+    | "ADVANCED_DATA_TYPE_ADD"
+    | "ADVANCED_DATA_TYPE_EDIT"
+    | "ADVANCED_DATA_TYPE_REMOVE"
+    | "TAGS_VIEW"
+    | "TAGS_MANAGE"
+    | "VALIDATION_EXECUTION"
+    | "ACCESS_DATA"
+    | "VIEW_SAMPLES"
+    | "RELATION_TYPE_ADD"
+    | "RELATION_TYPE_REMOVE"
+    | "RELATION_TYPE_CHANGE"
+    | "REGISTER_PROFILING_INFORMATION"
+    | "REPORTING_DOWNLOAD_INSIGHTS_DATA"
+    | "REPORTING_VIEW_INSIGHTS_REPORTS"
+    | "INSIGHTS_VIEW"
+    | "TECHNICAL_LINEAGE"
+    | "LOGS_VIEW"
+    | "RESOURCE_MANAGE_ALL"
+    | "CONFIGURATION_VIEW"
+    | "CONFIGURATION_EDIT"
+    | "BACKSTORE_VIEW"
+    | "BACKSTORE_EDIT"
+    | "ASSESSMENTS"
+    | "METADATA_LAKE"
+
+  type Role = NamedResource & {
+    description: string
+    permissions: Permission[]
+    global: boolean
+  }
+
+  export type WorkflowDefinition = Resource & {
+    name: string
+    description: string
+    processId: string
+    startLabel: string
+    formRequired: boolean
+    startFormKeyAvailable: boolean
+    startFormJsonModelAvailable: boolean
+    enabled: boolean
+    domainAssignmentRules: NamedResourceReference[]
+    assetAssignmentRules: NamedResourceReference[]
+    businessItemResourceType: "ASSET" | "DOMAIN" | "COMMUNITY" | "GLOBAL"
+    exclusivity: "RESOURCE_EXCLUSIVITY" | "DEFINITION_EXCLUSIVITY" | "UNCONSTRAINED"
+    guestUserAccessible: boolean
+    registeredUserAccessible: boolean
+    candidateUserCheckEnabled: boolean
+    globalCreate: boolean
+    startEvents:
+      | "ASSET_ADDED"
+      | "ASSET_REMOVED"
+      | "ASSET_STATUS_CHANGED"
+      | "ASSET_DOMAIN_CHANGED"
+      | "ASSET_TYPE_CHANGED"
+      | "ASSET_ATTRIBUTE_CHANGED"
+      | "ASSET_NAME_CHANGED"
+      | "ASSET_DISPLAY_NAME_CHANGED"
+      | "ASSET_ATTRIBUTE_ADDED"
+      | "ASSET_ATTRIBUTE_REMOVED"
+      | "DOMAIN_ADDED"
+      | "DOMAIN_REMOVED"
+      | "ROLE_GRANTED"
+      | "ROLE_REVOKED"
+      | "WORKFLOW_STARTED"
+      | "WORKFLOW_CANCELED"
+      | "WORKLFLOW_ESCALATION"
+      | "WORKFLOW_TASK_COMPLETED"
+      | "USER_ADDED"
+      | "USER_REMOVED"
+      | "USER_DISABLED"
+      | "COMMENT_ADDED"
+      | "COMMENT_REMOVED"
+      | "COMMENT_CHANGED"
+      | "RELATION_ADDED_AND_ASSET_IS_SOURCE"
+      | "RELATION_REMOVED_AND_ASSET_WAS_SOURCE"
+      | "RELATION_ADDED_AND_ASSET_IS_TARGET"
+      | "RELATION_REMOVED_AND_ASSET_WAS_TARGET"
+      | "TAG_ASSIGN_CHANGED"
+      | "CLASSIFICATION_MATCH_ACCEPTED"
+      | "CLASSIFICATION_MATCH_REJECTED"
+      | "CLASSIFICATION_MATCH_ADDED"
+      | "CLASSIFICATION_MATCH_REMOVED"
+      | "CLASSIFICATION_MATCH_UPDATED"
+      | "DATABASE_REGISTRATION_COMPLETED"
+      | "DATABASE_REGISTRATION_FAILED"
+    configurationVariables: Record<string, string>
+    startRoles: Role[]
+    stopRoles: Role[]
+    reassignRoles: Role[]
+  }
+
+  type WorkflowDefinitionReference = {
+    id: string
+    resourceType: ResourceType
+    name: string
+    processId: string
+  }
+
+  type OptionValue = {
+    label: string
+    value: string
+  }
+
+  type DropdownValue = {
+    parents: string[]
+    idAsString: string
+    id: string
+    text: string
+  }
+
+  type FormProperty = {
+    id: string
+    name: string
+    type: string
+    value: string
+    writable: boolean
+    required: boolean
+    enumValues: DropdownValue[]
+    checkButtons: OptionValue[]
+    radioButtons: OptionValue[]
+    defaultDropdownValues: DropdownValue[]
+    proposedDropdownValues: DropdownValue[]
+    dateTimeType: string
+    multiValue: boolean
+    proposedFixed: boolean
+    defaultFromResource: boolean
+    multiDefaultDropdownValues: Record<string, DropdownValue[]>
+    multiProposedDropdownValues: Record<string, DropdownValue[]>
+    assetType: ResourceReference
+    communityIds: string[]
+    domainIds: string[]
+    statusIds: string[]
+  }
+
+  export type WorkflowTask = {
+    id: string
+    system: boolean
+    resourceType: ResourceType
+    workflowDefinition: WorkflowDefinitionReference
+    workflowInstanceId: string
+    key: string
+    type: string
+    aggregationKey: string
+    priority: number
+    owner: string
+    candidateUsers: User[]
+    createTime: number
+    dueDate: number
+    cancelable: boolean
+    reassignable: boolean
+    formRequired: boolean
+    formKeyAvailable: boolean
+    containsActivityStream: boolean
+    inError: boolean
+    errorMessage: string
+    customButtons: FormProperty[]
+    description: string
+    title: string
+    businessItem: ResourceReference
+    businessItemReference: NamedResourceReference
+  }
+
+  export type SearchResult = {
+    resource: Resource
+    highlights: {
+      field: string
+      fragment: string
+      id: string
+    }[]
+  }
+
+  type PagedQueryParams = Partial<{
+    offset: number
+    limit: number
+    countLimit: number
+  }>
+
+  type NameableQueryParams = Partial<
+    PagedQueryParams & {
+      name: string
+      nameMatchMode: "START" | "END" | "ANYWHERE" | "EXACT"
+    }
+  >
+
+  type SortableQueryParams<F> = Partial<{
+    sortField: F
+    sortOrder: "ASC" | "DESC"
+  }>
+
+  export type AssetQueryParams = Partial<
+    PagedQueryParams &
+      NameableQueryParams &
+      SortableQueryParams<"NAME" | "DISPLAY_NAME"> & {
+        domainId: string
+        communityId: string
+        typeIds: string[]
+        statusIds: string[]
+        tagNames: string[]
+        typeInheritance: boolean
+        excludeMeta: boolean
+      }
+  >
+
+  export type SearchResponse = {
+    total: number
+    results: SearchResult[]
+    aggregations: {
+      field: string
+      values: {
+        id: string
+        count: number
+      }[]
+    }[]
   }
 
   export interface PagedResponse<T = any> {
@@ -11,5 +525,32 @@ declare namespace Collibra {
     results: T[]
   }
 
-  export interface PagedCommunityResponse extends PagedResponse<Community> {}
+  export type PagedAttributeResponse = PagedResponse<Attribute>
+  export type PagedAssetResponse = PagedResponse<Asset>
+  export type PagedResponsibilityResponse = PagedResponse<Responsibility>
+  export type PagedUserResponse = PagedResponse<User>
+  export type PagedNavigationStatisticResponse = PagedResponse<NavigationStatistic>
+  export type PagedCommunityResponse = PagedResponse<Community>
+  export type PagedWorkflowDefinitionResponse = PagedResponse<WorkflowDefinition>
+  export type PagedDomainResponse = PagedResponse<Domain>
+  export type PagedStatusResponse = PagedResponse<Status>
+  export type PagedAssetTypeResponse = PagedResponse<AssetType>
+  export type PagedRelationTypeResponse = PagedResponse<RelationType>
+  export type PagedRelationResponse = PagedResponse<Relation> & {
+    nextCursor: string
+  }
+
+  export type WorkflowInstance = Resource & {
+    workflowDefinition: WorkflowDefinitionReference
+    subInstances: any[]
+    subProcessInstancesCount: number
+    parentWorkflowInstanceId: string
+    businessItem: ResourceReference
+    tasks: WorkflowTask[]
+    startDate: number
+    ended: boolean
+    createdAssetId: string
+    inError: boolean
+    errorMessage: string
+  }
 }

--- a/lib/attemptAccessTokenRefresh.ts
+++ b/lib/attemptAccessTokenRefresh.ts
@@ -2,6 +2,7 @@ import { JWT } from "next-auth/jwt"
 
 import { ERR_CODES } from "./errors"
 import { AuthError } from "./errors/AuthError"
+import { getTokenExpirationTime } from "./getTokenExpirationTime"
 
 import { config } from "config"
 
@@ -45,7 +46,7 @@ export const attemptAccessTokenRefresh = async (token: Token) => {
     return {
       ...token,
       accessToken: data.access_token,
-      expiresAt: Date.now() + data.expires_in * 1000,
+      expiresAt: getTokenExpirationTime(data.access_token),
       refreshToken: data.refresh_token ?? token.refreshToken, // Fall back to old refresh token
     }
   } catch (err) {

--- a/lib/getTokenExpirationTime.ts
+++ b/lib/getTokenExpirationTime.ts
@@ -1,0 +1,6 @@
+import jwt, { JwtPayload } from "jsonwebtoken"
+
+export const getTokenExpirationTime = (token: string) => {
+  const { exp } = jwt.decode(token) as JwtPayload
+  return new Date((exp as number) * 1000).valueOf() - 6000 * 5
+}

--- a/lib/net/request.ts
+++ b/lib/net/request.ts
@@ -1,0 +1,42 @@
+import { getToken, type JWT, type GetTokenParams } from "next-auth/jwt"
+
+import { HttpError } from "lib/HttpError"
+
+type ReqInit = RequestInit & {
+  retries?: number
+}
+
+export const request =
+  (url: string, init?: ReqInit) =>
+  async (sessionParams?: GetTokenParams): Promise<Response> => {
+    const req = new Request(url, {
+      redirect: "follow",
+      ...init,
+    })
+
+    let session: JWT | undefined
+
+    if (sessionParams) {
+      session = (await getToken(sessionParams)) as JWT
+      req.headers.set("Authorization", `Bearer ${session.accessToken}`)
+    }
+
+    const res = await fetch(req)
+
+    if (res.status === 401 && init?.retries && init.retries > 0) {
+      return request(req.url, {
+        ...req,
+        retries: init.retries - 1,
+      })(sessionParams)
+    }
+
+    if (!res.ok && !init?.retries) {
+      throw new HttpError(
+        `${req.method} to ${req.url} failed with ${res.status} (${res.statusText})`,
+        res.status,
+        res.headers
+      )
+    }
+
+    return res
+  }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "dotenv": "^16.0.3",
         "instantsearch.js": "^4.49.4",
         "jsdom": "^20.0.3",
+        "jsonwebtoken": "^9.0.0",
         "next": "^13.1.1",
         "next-auth": "^4.18.7",
         "query-string": "^8.1.0",
@@ -3586,6 +3587,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4247,6 +4253,14 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
@@ -7260,6 +7274,21 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash": "^4.17.21",
+        "ms": "^2.1.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
@@ -7271,6 +7300,25 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/kleur": {
@@ -9051,6 +9099,25 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -9121,10 +9188,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -13049,6 +13115,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -13565,6 +13636,14 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "electron-to-chromium": {
       "version": "1.4.284",
@@ -15786,6 +15865,17 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonwebtoken": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash": "^4.17.21",
+        "ms": "^2.1.1",
+        "semver": "^7.3.8"
+      }
+    },
     "jsx-ast-utils": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
@@ -15794,6 +15884,25 @@
       "requires": {
         "array-includes": "^3.1.5",
         "object.assign": "^4.1.2"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kleur": {
@@ -17044,6 +17153,11 @@
         }
       }
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
     "safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -17099,10 +17213,9 @@
       "integrity": "sha512-fXwC0QzkBGZuGTb6FoQG+iLS81wljYuBU4Sco4TGTgp5boVkiKZeFqPV0e5h5++5QncTU2FQrQ+G3ILnqEa3yA=="
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dotenv": "^16.0.3",
     "instantsearch.js": "^4.49.4",
     "jsdom": "^20.0.3",
+    "jsonwebtoken": "^9.0.0",
     "next": "^13.1.1",
     "next-auth": "^4.18.7",
     "query-string": "^8.1.0",

--- a/pages/api/communities.ts
+++ b/pages/api/communities.ts
@@ -1,50 +1,34 @@
 import { NextApiHandler } from "next"
-import { getToken } from "next-auth/jwt"
 
 import { config } from "config"
-import { HttpClient } from "lib/HttpClient"
 import { HttpError } from "lib/HttpError"
+import { request } from "lib/net/request"
 
 const CommunitiesHandler: NextApiHandler = async (req, res) => {
   if (req.method !== "GET") {
     return res.status(405).end()
   }
 
-  const token = await getToken({ req })
-
-  if (!token) {
-    return res.status(401).end()
-  }
-
-  const authorization = `Bearer ${token.accessToken}`
-
   try {
-    const allComunities = await HttpClient.get<Collibra.PagedCommunityResponse>(
-      `${config.COLLIBRA_API_URL}/communities`,
-      {
-        headers: { authorization },
-        query: {
-          name: "equinor",
-          nameMatchMode: "ANYWHERE",
-        },
-      }
-    )
+    const communitiesParams = new URLSearchParams({ name: "equinor", nameMatchMode: "ANYWHERE" }).toString()
 
-    const equinorCommunity = allComunities.body?.results[0]
+    const allCommunitiesRes = await request(`${config.COLLIBRA_API_URL}/communities?${communitiesParams}`, {
+      retries: 3,
+    })({ req })
+    const allComunities: Collibra.PagedCommunityResponse = await allCommunitiesRes.json()
+
+    const equinorCommunity = allComunities.results[0]
 
     if (!equinorCommunity) {
       return res.status(500).end()
     }
 
-    const communities = await HttpClient.get<Collibra.PagedCommunityResponse>(
-      `${config.COLLIBRA_API_URL}/communities`,
-      {
-        headers: { authorization },
-        query: { parentId: equinorCommunity.id },
-      }
-    )
+    const communitiesRes = await request(`${config.COLLIBRA_API_URL}/communities?parentId=${equinorCommunity.id}`)({
+      req,
+    })
+    const communities: Collibra.PagedCommunityResponse = await communitiesRes.json()
 
-    return res.json(communities.body?.results)
+    return res.json(communities.results)
   } catch (error) {
     /* eslint-disable no-console  */
     console.log("[CommunitiesHandler]", error)


### PR DESCRIPTION
This pull request aims to resolve the issues we've been facing with users receiving 401s from the first API requests performed when the app is opened after a considerable amount of time of inactivity.

The solution isn't the most elegant, but it boils down to running `getToken` again if the API call fails with a 401.

[SWR](https://swr.vercel.app) should allow us to make retrying API requests easier, but out of scope for this pull request, as it'd require a larger rewrite.

Solves [AB#97995](https://dev.azure.com/EquinorASA/d02c350d-092d-41bf-a812-f05d5d8ad1b0/_workitems/edit/97995)